### PR TITLE
Add CS2 portfolio static site

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CS2 Portfolio</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="app">
+    <header class="app__header">
+      <div class="app__title-group">
+        <h1>CS2 Portfolio</h1>
+        <p>Steam Community Market · Letzte Aktualisierung: <span id="lastUpdated"></span></p>
+      </div>
+      <div class="app__summary">
+        <div>
+          <span class="summary__label">Gesamtwert</span>
+          <span class="summary__value" id="totalValue"></span>
+        </div>
+        <div>
+          <span class="summary__label">Gesamtänderung (24h)</span>
+          <span class="summary__change" id="totalChange"></span>
+        </div>
+      </div>
+    </header>
+
+    <section class="card">
+      <div class="card__header">
+        <div>
+          <h2>Holdings</h2>
+          <p>CS2 Items · Quelle: Steam Community Market</p>
+        </div>
+        <div class="card__header-summary">
+          <span id="itemsCount"></span>
+          <span id="casesCount"></span>
+        </div>
+      </div>
+      <div class="table">
+        <div class="table__header">
+          <span class="table__col table__col--item">Item</span>
+          <span class="table__col">Anzahl</span>
+          <span class="table__col">Gesamtwert</span>
+          <span class="table__col">Änderung</span>
+          <span class="table__col table__col--allocation">Allokation</span>
+        </div>
+        <div class="table__body" id="portfolioRows"></div>
+      </div>
+    </section>
+
+    <footer class="app__footer">
+      <p>Marktdaten basieren auf öffentlichen Preisen des <a href="https://steamcommunity.com/market/" target="_blank" rel="noopener">Steam Community Market</a>.</p>
+    </footer>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,108 @@
+const portfolioData = [
+  {
+    name: 'Prisma Case',
+    type: 'Case',
+    description: '5000x · Normal Grade Container',
+    quantity: 5000,
+    unitPrice: 0.18,
+    changeValue: -125.0,
+    changePercent: -12.9,
+    image: 'https://steamcommunity-a.akamaihd.net/economy/image/f0q0AR83yjEp11TWMupfOXHxL9iqwJstiAhKq5yRvPrkt8/128fx128f',
+    marketUrl: 'https://steamcommunity.com/market/listings/730/Prisma%20Case'
+  },
+  {
+    name: 'Glove Case',
+    type: 'Case',
+    description: '3x · Extraordinary Gloves Collection',
+    quantity: 3,
+    unitPrice: 2.55,
+    changeValue: 3.75,
+    changePercent: 5.2,
+    image: 'https://steamcommunity-a.akamaihd.net/economy/image/cdljhcVLY0fjtYVFmKuhCwHMTZqjC9nGZRQ2JWpeb1wD/128fx128f',
+    marketUrl: 'https://steamcommunity.com/market/listings/730/Glove%20Case'
+  },
+  {
+    name: 'M4A1-S | Leaded Glass (Fabrikneu)',
+    type: 'Rifle Skin',
+    description: '1x · Factory New',
+    quantity: 1,
+    unitPrice: 17.85,
+    changeValue: 1.12,
+    changePercent: 2.7,
+    image: 'https://steamcommunity-a.akamaihd.net/economy/image/4b8nE2HnIrklJy1DyWv3Y9o0RQ_8ljyiE4bItKOM4iP6HTR1X6K8OiyFXp1kXEiXS_5icPf3HG0WcU-nVTY8Gg/128fx128f',
+    marketUrl: 'https://steamcommunity.com/market/listings/730/M4A1-S%20%7C%20Leaded%20Glass%20(Factory%20New)'
+  }
+];
+
+const formatter = new Intl.NumberFormat('de-DE', {
+  style: 'currency',
+  currency: 'EUR'
+});
+
+const formatChange = (value, percent) => {
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${formatter.format(value)} (${sign}${percent.toFixed(1)}%)`;
+};
+
+const portfolioRows = document.getElementById('portfolioRows');
+const totalValueEl = document.getElementById('totalValue');
+const totalChangeEl = document.getElementById('totalChange');
+const lastUpdatedEl = document.getElementById('lastUpdated');
+const itemsCountEl = document.getElementById('itemsCount');
+const casesCountEl = document.getElementById('casesCount');
+
+const totalValue = portfolioData.reduce((sum, item) => sum + item.unitPrice * item.quantity, 0);
+const totalChange = portfolioData.reduce((sum, item) => sum + item.changeValue, 0);
+
+const caseItems = portfolioData.filter((item) => item.type === 'Case');
+const totalCases = caseItems.reduce((sum, item) => sum + item.quantity, 0);
+
+portfolioData.forEach((item) => {
+  const row = document.createElement('a');
+  row.href = item.marketUrl;
+  row.target = '_blank';
+  row.rel = 'noopener';
+  row.className = 'table__row';
+
+  const totalItemValue = item.unitPrice * item.quantity;
+  const allocation = (totalItemValue / totalValue) * 100;
+  const isPositive = item.changeValue >= 0;
+
+  row.innerHTML = `
+    <span class="table__col table__col--item">
+      <span class="item__image">
+        <img src="${item.image}" alt="${item.name}" loading="lazy" />
+      </span>
+      <span class="item__meta">
+        <span class="item__title">${item.name}</span>
+        <span class="item__subtitle">${item.description}</span>
+      </span>
+    </span>
+    <span class="table__col amount">${item.quantity.toLocaleString('de-DE')}</span>
+    <span class="table__col value">${formatter.format(totalItemValue)}</span>
+    <span class="table__col change" data-positive="${isPositive}">${formatChange(item.changeValue, item.changePercent)}</span>
+    <span class="table__col allocation">
+      <span class="allocation__progress"><span style="width: ${allocation.toFixed(1)}%"></span></span>
+      <span class="allocation__label">${allocation.toFixed(1)}%</span>
+    </span>
+  `;
+
+  portfolioRows.appendChild(row);
+});
+
+totalValueEl.textContent = formatter.format(totalValue);
+
+totalChangeEl.textContent = formatChange(totalChange, (totalChange / (totalValue - totalChange)) * 100 || 0);
+totalChangeEl.dataset.positive = totalChange >= 0;
+
+itemsCountEl.textContent = `${portfolioData.length} Positionen`;
+casesCountEl.textContent = `${totalCases.toLocaleString('de-DE')} Cases insgesamt`;
+
+const updated = new Date();
+lastUpdatedEl.textContent = updated.toLocaleString('de-DE', {
+  day: '2-digit',
+  month: 'long',
+  year: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit'
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,344 @@
+:root {
+  --bg-gradient: radial-gradient(circle at top left, #1f2a52 0%, #0b1023 45%, #080b16 100%);
+  --card-bg: rgba(18, 24, 44, 0.85);
+  --row-bg: rgba(15, 21, 40, 0.75);
+  --row-hover: rgba(40, 51, 91, 0.9);
+  --border-color: rgba(255, 255, 255, 0.05);
+  --text-primary: #f4f7ff;
+  --text-secondary: rgba(244, 247, 255, 0.6);
+  --positive: #21c78a;
+  --negative: #ff6b6b;
+  --accent: #4f8aff;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg-gradient);
+  color: var(--text-primary);
+  display: flex;
+  justify-content: center;
+  padding: 3.5rem 1.5rem;
+}
+
+.app {
+  width: min(1100px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.app__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.app__title-group h1 {
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  margin: 0 0 0.2rem 0;
+  font-weight: 600;
+}
+
+.app__title-group p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.app__summary {
+  display: flex;
+  gap: 2.75rem;
+  align-items: flex-end;
+}
+
+.summary__label {
+  display: block;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  margin-bottom: 0.35rem;
+}
+
+.summary__value {
+  font-size: clamp(1.6rem, 3vw, 2.1rem);
+  font-weight: 600;
+}
+
+.summary__change {
+  font-size: 1.1rem;
+  font-weight: 500;
+}
+
+.summary__change[data-positive="true"] {
+  color: var(--positive);
+}
+
+.summary__change[data-positive="false"] {
+  color: var(--negative);
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 22px;
+  padding: 1.75rem 2rem;
+  backdrop-filter: blur(18px);
+  box-shadow: 0 28px 60px rgba(6, 11, 25, 0.45);
+}
+
+.card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.75rem;
+}
+
+.card__header h2 {
+  margin: 0;
+  font-size: 1.3rem;
+  font-weight: 600;
+}
+
+.card__header p {
+  margin: 0.35rem 0 0 0;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.card__header-summary {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.table {
+  border-top: 1px solid var(--border-color);
+}
+
+.table__header,
+.table__row {
+  display: grid;
+  grid-template-columns: 2fr 0.9fr 1.1fr 1fr 1.1fr;
+  align-items: center;
+  padding: 0.85rem 0;
+  gap: 1rem;
+}
+
+.table__header {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.09rem;
+}
+
+.table__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.table__row {
+  background: var(--row-bg);
+  padding: 0.9rem 1.2rem;
+  border-radius: 16px;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.table__row:hover {
+  background: var(--row-hover);
+  transform: translateY(-2px);
+}
+
+.table__col--item {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.item__image {
+  width: 60px;
+  height: 60px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.08);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.item__image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.item__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.item__title {
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--text-primary);
+}
+
+.item__subtitle {
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+}
+
+.amount {
+  font-weight: 500;
+  font-size: 1rem;
+}
+
+.value {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.change {
+  font-weight: 500;
+  font-size: 0.98rem;
+}
+
+.change[data-positive="true"] {
+  color: var(--positive);
+}
+
+.change[data-positive="false"] {
+  color: var(--negative);
+}
+
+.allocation {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.allocation__progress {
+  flex: 1;
+  height: 6px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  overflow: hidden;
+  position: relative;
+}
+
+.allocation__progress span {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(79, 138, 255, 0.95), rgba(111, 199, 255, 0.95));
+  border-radius: inherit;
+}
+
+.allocation__label {
+  font-size: 0.92rem;
+  color: var(--text-secondary);
+  min-width: 3.5rem;
+  text-align: right;
+}
+
+.app__footer {
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.app__footer a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.app__footer a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 900px) {
+  body {
+    padding: 2rem 1.2rem;
+  }
+
+  .app__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .app__summary {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .card__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .card__header-summary {
+    width: 100%;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
+  .table__header,
+  .table__row {
+    grid-template-columns: minmax(0, 2.5fr) repeat(3, minmax(0, 1fr));
+    grid-template-areas:
+      "item item item item"
+      "amount value change allocation";
+    row-gap: 0.75rem;
+  }
+
+  .table__col--item,
+  .table__row .table__col:nth-child(1) {
+    grid-area: item;
+  }
+
+  .table__row .table__col:nth-child(2) {
+    grid-area: amount;
+  }
+
+  .table__row .table__col:nth-child(3) {
+    grid-area: value;
+  }
+
+  .table__row .table__col:nth-child(4) {
+    grid-area: change;
+  }
+
+  .table__row .table__col:nth-child(5) {
+    grid-area: allocation;
+  }
+}
+
+@media (max-width: 600px) {
+  .app {
+    gap: 1.5rem;
+  }
+
+  .summary__value {
+    font-size: 1.6rem;
+  }
+
+  .summary__change {
+    font-size: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- create a dark-themed CS2 holdings dashboard inspired by the provided design
- include structured cards with live-calculated totals for holdings and allocation
- add static Steam Market-linked data for Prisma Case, Glove Case, and M4A1-S | Leaded Glass

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cc00bafb7c8327993eb95b5929f5bd