### PR TITLE
Fix Steam metadata parsing and price fallbacks

### DIFF
--- a/script.js
+++ b/script.js
@@ -193,6 +193,7 @@ const parsePriceString = (priceString) => {
   }
 
   const normalized = priceString
+    .trim()
     .replace(/\./g, '')
     .replace(',', '.')
     .replace(/[^\d.-]/g, '');
@@ -221,15 +222,19 @@ const fetchLowestPrice = async (item) => {
 
     const data = await response.json();
 
-    if (data.success && data.lowest_price) {
-      const price = parsePriceString(data.lowest_price);
+    if (data.success) {
+      const priceString = data.lowest_price ?? data.median_price ?? null;
 
-      if (price !== null) {
-        return {
-          ...item,
-          unitPrice: price,
-          currency: 'EUR'
-        };
+      if (priceString) {
+        const price = parsePriceString(priceString);
+
+        if (price !== null) {
+          return {
+            ...item,
+            unitPrice: price,
+            currency: 'EUR'
+          };
+        }
       }
     }
   } catch (error) {


### PR DESCRIPTION
## Summary
- decode Steam listing image URLs and parse og:image tags so fetched item images render reliably
- fall back to median price strings and trim API responses before parsing to keep valuations aligned with Steam data

## Testing
- npm start (manually interrupted after verifying server startup)


------
https://chatgpt.com/codex/tasks/task_e_68d9b667dee08327861d0ad7367c9789