### PR TITLE
Persist Steam item images locally

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,16 +1,114 @@
 'use strict';
 
+const crypto = require('crypto');
 const express = require('express');
+const fs = require('fs');
+const fsPromises = require('fs/promises');
 const path = require('path');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 const STEAM_PRICE_ENDPOINT = 'https://steamcommunity.com/market/priceoverview/';
 const STEAM_LISTING_BASE = 'https://steamcommunity.com/market/listings/730/';
-const IMAGE_CACHE_TTL = 1000 * 60 * 60; // 1 hour
+const IMAGE_CACHE_TTL = 1000 * 60 * 60 * 24 * 30; // 30 days
+const IMAGE_CACHE_DIR = path.join(__dirname, 'cached_images');
+const IMAGE_CACHE_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.webp'];
 const imageCache = new Map();
 
 app.use(express.static(path.join(__dirname)));
+
+if (!fs.existsSync(IMAGE_CACHE_DIR)) {
+  fs.mkdirSync(IMAGE_CACHE_DIR, { recursive: true });
+}
+
+const hashMarketHashName = (marketHashName) =>
+  crypto.createHash('sha1').update(marketHashName).digest('hex');
+
+const resolveCachedImagePath = async (marketHashName) => {
+  const hash = hashMarketHashName(marketHashName);
+
+  for (const ext of IMAGE_CACHE_EXTENSIONS) {
+    const filePath = path.join(IMAGE_CACHE_DIR, `${hash}${ext}`);
+
+    try {
+      await fsPromises.access(filePath, fs.constants.F_OK);
+      return filePath;
+    } catch (error) {
+      // Continue searching other extensions
+    }
+  }
+
+  return null;
+};
+
+const contentTypeToExtension = (contentType = '') => {
+  if (contentType.includes('png')) {
+    return '.png';
+  }
+
+  if (contentType.includes('webp')) {
+    return '.webp';
+  }
+
+  if (contentType.includes('jpeg')) {
+    return '.jpeg';
+  }
+
+  if (contentType.includes('jpg')) {
+    return '.jpg';
+  }
+
+  return '.png';
+};
+
+const removeStaleImageVariants = async (hash, extensionToKeep) => {
+  await Promise.all(
+    IMAGE_CACHE_EXTENSIONS.filter((ext) => ext !== extensionToKeep).map(async (ext) => {
+      const variantPath = path.join(IMAGE_CACHE_DIR, `${hash}${ext}`);
+
+      try {
+        await fsPromises.unlink(variantPath);
+      } catch (error) {
+        if (error.code !== 'ENOENT') {
+          console.warn(`Failed to remove cached variant ${variantPath}:`, error);
+        }
+      }
+    })
+  );
+};
+
+const persistImageToCache = async (marketHashName, buffer, contentType) => {
+  const hash = hashMarketHashName(marketHashName);
+  const extension = contentTypeToExtension(contentType);
+  const filePath = path.join(IMAGE_CACHE_DIR, `${hash}${extension}`);
+
+  await removeStaleImageVariants(hash, extension);
+  await fsPromises.writeFile(filePath, buffer);
+
+  return filePath;
+};
+
+const toWebPath = (absolutePath) => `/${path.relative(__dirname, absolutePath).replace(/\\/g, '/')}`;
+
+const downloadAndCacheImage = async (marketHashName, imageUrl) => {
+  const response = await fetch(imageUrl, {
+    headers: {
+      'User-Agent': 'cs2-portfolio-tool/1.0',
+      Accept: 'image/avif,image/webp,image/apng,image/*,*/*;q=0.8'
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`Steam image responded with ${response.status}`);
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+  const contentType = response.headers.get('content-type') || '';
+
+  const cachedPath = await persistImageToCache(marketHashName, buffer, contentType);
+  return toWebPath(cachedPath);
+};
 
 app.get('/api/price', async (req, res) => {
   const appId = (req.query.appid || '730').toString();
@@ -48,11 +146,52 @@ app.get('/api/price', async (req, res) => {
   }
 });
 
+const decodeSteamImageUrl = (value) => {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const normalized = value.replace(/"/g, '\"');
+    return JSON.parse(`"${normalized}"`);
+  } catch (error) {
+    return value
+      .replace(/\\\//g, '/')
+      .replace(/\\u0026/g, '&')
+      .replace(/&amp;/g, '&');
+  }
+};
+
+const extractSteamImageUrl = (html) => {
+  const metaMatch = html.match(/<meta[^>]+property=["']og:image["'][^>]+content=["']([^"']+)["']/i);
+
+  if (metaMatch && metaMatch[1]) {
+    return decodeSteamImageUrl(metaMatch[1]);
+  }
+
+  const genericMatch = html.match(/https:\/\/[^"\\]*economy\/image\/[^"\\]*/);
+
+  if (genericMatch && genericMatch[0]) {
+    return decodeSteamImageUrl(genericMatch[0]);
+  }
+
+  return null;
+};
+
 app.get('/api/item-meta', async (req, res) => {
   const marketHashName = req.query.marketHashName;
 
   if (!marketHashName) {
     return res.status(400).json({ success: false, error: 'missing_market_hash_name' });
+  }
+
+  const cachedImagePath = await resolveCachedImagePath(marketHashName);
+
+  if (cachedImagePath) {
+    const webPath = toWebPath(cachedImagePath);
+    imageCache.set(marketHashName, { image: webPath, timestamp: Date.now() });
+    res.set('Cache-Control', 'public, max-age=86400');
+    return res.json({ success: true, image: webPath });
   }
 
   const cached = imageCache.get(marketHashName);
@@ -75,17 +214,23 @@ app.get('/api/item-meta', async (req, res) => {
     }
 
     const html = await response.text();
-    const match = html.match(/https:\/\/[^"\\]*economy\/image\/[^"\\]*/);
-    const image = match ? match[0] : null;
+    const image = extractSteamImageUrl(html);
 
-    imageCache.set(marketHashName, { image, timestamp: Date.now() });
-
-    if (image) {
-      res.set('Cache-Control', 'public, max-age=3600');
-      return res.json({ success: true, image });
+    if (!image) {
+      imageCache.set(marketHashName, { image: null, timestamp: Date.now() });
+      return res.status(404).json({ success: false, error: 'image_not_found' });
     }
 
-    return res.status(404).json({ success: false, error: 'image_not_found' });
+    try {
+      const cachedPath = await downloadAndCacheImage(marketHashName, image);
+      imageCache.set(marketHashName, { image: cachedPath, timestamp: Date.now() });
+      res.set('Cache-Control', 'public, max-age=86400');
+      return res.json({ success: true, image: cachedPath });
+    } catch (downloadError) {
+      console.error('Failed to persist Steam image locally:', downloadError);
+      imageCache.set(marketHashName, { image, timestamp: Date.now() });
+      return res.json({ success: true, image });
+    }
   } catch (error) {
     console.error('Steam item meta fetch failed:', error);
     imageCache.set(marketHashName, { image: null, timestamp: Date.now() });


### PR DESCRIPTION
## Summary
- add a disk-backed cache for Steam item images so the API reuses locally saved copies on later requests
- persist downloaded images with content-type aware extensions and expose them via Express static hosting
- update the frontend image loader to request cached artwork even for items with pre-seeded URLs so it swaps to the local files once available

## Testing
- npm start (manually stopped after verifying the server booted)


------
https://chatgpt.com/codex/tasks/task_e_68d9b667dee08327861d0ad7367c9789